### PR TITLE
Reintroduce thumbfast thumbnail background

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -1256,10 +1256,21 @@ function render_elements(master_ass)
                         if osd_w and not thumbfast.disabled then
                             local r_w, r_h = get_virt_scale_factor()
 
+                            local thumbPad = 4
                             local thumbMarginX = 18 / r_w
                             local thumbMarginY = 40
+                            local tooltipBgColor = "FFFFFF"
+                            local tooltipBgAlpha = 80
                             local thumbX = math.min(osd_w - thumbfast.width - thumbMarginX, math.max(thumbMarginX, tx / r_w - thumbfast.width / 2))
                             local thumbY = ((ty - thumbMarginY) / r_h - thumbfast.height)
+
+                            elem_ass:new_event()
+                            elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
+                            elem_ass:an(7)
+                            elem_ass:append(("{\\bord0\\1c&H%s&\\1a&H%X&}"):format(tooltipBgColor, tooltipBgAlpha))
+                            elem_ass:draw_start()
+                            elem_ass:rect_cw(-thumbPad * r_h, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                            elem_ass:draw_stop()
 
                             mp.commandv("script-message-to", "thumbfast", "thumb",
                                 mp.get_property_number("duration", 0) * (sliderpos / 100),


### PR DESCRIPTION
I've finally been able to reproduce your issue in #3 and found how to fix it, it was an issue with the default alignment in 3rd party clients like Syncplay and MPV-EASY.  
So we can have a fancy thumbnail background/border again.