### PR TITLE
Update escape text function

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -1447,10 +1447,7 @@ function show_message(text, duration)
     -- may slow down massively on huge input
     text = string.sub(text, 0, 4000)
 
-    -- replace actual linebreaks with ASS linebreaks
-    text = string.gsub(text, "\n", "\\N")
-
-    state.message_text = text
+    state.message_text = mp.command_native({"escape-ass", text})
 
     if not state.message_hide_timer then
         state.message_hide_timer = mp.add_timeout(0, request_tick)
@@ -1649,9 +1646,8 @@ function window_controls()
         ne = new_element("wctitle", "button")
         ne.content = function ()
             local title = mp.command_native({"expand-text", user_opts.title})
-            -- escape ASS, and strip newlines and trailing slashes
-            title = title:gsub("\\n", " "):gsub("\\$", ""):gsub("{","\\{")
-            return not (title == "") and title or "mpv"
+            title = title:gsub("\n", " ")
+        return title ~= "" and mp.command_native({"escape-ass", title}) or "mpv"
         end
         ne.hoverable = false
         local left_pad = 5
@@ -1896,9 +1892,8 @@ function osc_init()
     ne.content = function ()
         local title = state.forced_title or
                       mp.command_native({"expand-text", user_opts.title})
-        -- escape ASS, and strip newlines and trailing slashes
-        title = title:gsub("\\n", " "):gsub("\\$", ""):gsub("{","\\{")
-        return not (title == "") and title or "mpv"
+                      title = title:gsub("\n", " ")
+                      return title ~= "" and mp.command_native({"escape-ass", title}) or "mpv"
     end
 
     ne.eventresponder["mbtn_left_up"] = function ()


### PR DESCRIPTION
With commit [d6610a5](https://github.com/mpv-player/mpv/commit/d6610a5b2f34e398e2ceba2a4da2b79e556b1c9e) being pushed with release v0.38.0, there is now a built in function for escaping ASS tags correctly. This commit implements this, and thus fixes a few issues with newlines not being escaped correctly.